### PR TITLE
Fix broken builds related to arm

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -51,7 +51,7 @@ jobs:
         with:
           context: .
           file: ./Dockerfile
-          platforms: linux/amd64,linux/arm64 #,linux/amd64/v2,linux/amd64/v3,linux/amd64/v4 #,linux/ppc64le,linux/s390x,linux/386,linux/arm/v7,linux/arm/v6
+          platforms: linux/amd64,linux/arm64/v8 #,linux/amd64/v2,linux/amd64/v3,linux/amd64/v4 #,linux/ppc64le,linux/s390x,linux/386,linux/arm/v7,linux/arm/v6
           push: true
           tags: |
             ${{ steps.un.outputs.un }}/${{ github.event.repository.name }}:${{ github.ref_name }}


### PR DESCRIPTION
Since the update to 3.2.5, builds have been failing on being unable to find the arm platform from the base image. Looking at https://hub.docker.com/layers/library/haproxy/3.2.5-alpine3.22/images/sha256-d2e683371950d5ff67ed26ddc639529edf684f9b591d215fc069864a8a64feb3 in dockerhub (and newer versions) it seems the arch is explicitly arm64/v8, I'm suspecting that the buildx task is defaulting to another variant when the variant isn't explicitly stated, so I'm hoping this will fix the builds